### PR TITLE
fix(delete-task): override headers

### DIFF
--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -29,6 +29,7 @@ apiClient.interceptors.request.use(
     const { access_token } = store.getState().auth
     config.headers = {
       Authorization: `Bearer ${access_token}`,
+      'If-Match': '*',
     }
     return config
   },


### PR DESCRIPTION
When deleting task, always got `412 error`. 
Found the workaround here, https://stackoverflow.com/questions/18380942/drive-api-files-patch-method-fails-with-precondition-failed-conditionnotmet