### PR TITLE
fix:  create new tasklist when no `items` returned

### DIFF
--- a/src/hooks/tasklists.ts
+++ b/src/hooks/tasklists.ts
@@ -2,7 +2,7 @@ import tasklistService from 'api/tasklists'
 import { useMutation, useQuery, useQueryClient } from 'react-query'
 import { useNavigation } from '@react-navigation/native'
 
-import { QueryKey, RouteName } from 'shared'
+import { QueryKey, RouteName, TasklistName } from 'shared'
 import { StackNavigationProps, TasklistQuery } from 'typings'
 import { useMemo } from 'react'
 
@@ -17,17 +17,20 @@ export const useFetchTasklistQuery = () => {
   }
 }
 
-export const useAddTasklistMutation = (title: string) => {
+export const useAddTasklistMutation = () => {
   const queryClient = useQueryClient()
   const navigation = useNavigation<StackNavigationProps>()
-  const mutation = useMutation(() => tasklistService.create(title), {
-    onSuccess: data => {
-      queryClient.invalidateQueries(QueryKey.Tasklists)
-      navigation.navigate(RouteName.NewTasklist, {
-        tasklist: data,
-      })
+  const mutation = useMutation(
+    () => tasklistService.create(TasklistName.UntitledList),
+    {
+      onSuccess: data => {
+        queryClient.invalidateQueries(QueryKey.Tasklists)
+        navigation.navigate(RouteName.NewTasklist, {
+          tasklist: data,
+        })
+      },
     },
-  })
+  )
   return mutation
 }
 

--- a/src/hooks/tasks.ts
+++ b/src/hooks/tasks.ts
@@ -3,8 +3,13 @@ import tasksService from 'api/tasks'
 import { useMemo } from 'react'
 import { useMutation, useQueries, useQuery, useQueryClient } from 'react-query'
 import { QueryKey, TaskStatus } from 'shared'
-import { StackNavigationProps } from 'typings'
-import { TaskQuery, Task, TaskPayload, Tasklist } from 'typings/task'
+import {
+  StackNavigationProps,
+  TaskQuery,
+  Task,
+  TaskPayload,
+  Tasklist,
+} from 'typings'
 
 export const useFetchTasksQuery = (
   tasklistId: string,
@@ -17,6 +22,9 @@ export const useFetchTasksQuery = (
     async () =>
       tasksService.findAll(tasklistId, showCompleted, showDeleted, showHidden),
   )
+  if (!queryResult.data || !queryResult.data.items) {
+    queryResult.data = { ...queryResult.data, items: [] }
+  }
   const needsActionTasks = useMemo(
     () =>
       queryResult.data?.items.filter(

--- a/src/hooks/tasks.ts
+++ b/src/hooks/tasks.ts
@@ -22,24 +22,20 @@ export const useFetchTasksQuery = (
     async () =>
       tasksService.findAll(tasklistId, showCompleted, showDeleted, showHidden),
   )
-  if (!queryResult.data || !queryResult.data.items) {
-    queryResult.data = { ...queryResult.data, items: [] }
-  }
-  const needsActionTasks = useMemo(
-    () =>
-      queryResult.data?.items.filter(
-        ({ status }) => status === TaskStatus.NeedsAction,
-      ),
-    [queryResult.data],
-  )
 
-  const compeletedTasks = useMemo(
-    () =>
-      queryResult.data?.items.filter(
-        ({ status }) => status === TaskStatus.Completed,
-      ),
-    [queryResult.data],
-  )
+  const needsActionTasks = useMemo(() => {
+    if (!queryResult.data?.items) return []
+    queryResult.data?.items.filter(
+      ({ status }) => status === TaskStatus.NeedsAction,
+    )
+  }, [queryResult.data])
+
+  const compeletedTasks = useMemo(() => {
+    if (!queryResult.data?.items) return []
+    queryResult.data?.items.filter(
+      ({ status }) => status === TaskStatus.Completed,
+    )
+  }, [queryResult.data])
   return {
     ...queryResult,
     data: {

--- a/src/modules/tasklists/TasklistsScreen.tsx
+++ b/src/modules/tasklists/TasklistsScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, StyleSheet, Text } from 'react-native'
 import { StackProps } from 'typings'
 import { windowHeight, windowWidth } from 'utils/dimensions'
 import TasklistItem from 'components/TasklistItem'
-import { theme, TasklistName } from 'shared'
+import { theme } from 'shared'
 import { useAddTasklistMutation, useFetchTasklistQuery } from 'hooks/tasklists'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import IconButton from 'components/IconButton'
@@ -12,7 +12,7 @@ import PlannedTasklistItem from 'components/PlannedTasklistItem'
 
 const TasklistsScreen = ({ navigation, route }: StackProps) => {
   const { isLoading, error, data: allTasklists } = useFetchTasklistQuery()
-  const addTasklistMutation = useAddTasklistMutation(TasklistName.UntitledList)
+  const addTasklistMutation = useAddTasklistMutation()
   useLayoutEffect(() =>
     navigation.setOptions({
       headerRight: () => <IconButton icon={faPlus} fn={handlePlus} />,

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -5,4 +5,10 @@ export type {
 } from './route'
 export type { Day } from './day'
 export type { Auth } from './auth'
-export type { Task, Tasklist, TasklistQuery } from './task'
+export type {
+  Task,
+  Tasklist,
+  TasklistQuery,
+  TaskQuery,
+  TaskPayload,
+} from './task'


### PR DESCRIPTION
When creating new tasklist, no `items` returned, so cannot get `needsActionTasks` and `compeletedTasks`, need set default value